### PR TITLE
Adding custom join messages.

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -183,7 +183,7 @@ class Bot(commands.Bot):
 
         channel_id = self.config.welcome_channel
         if channel_id is None:
-            self.log(f"CUSTOM_INVITE_CHANNEL environment variable is not defined. Member join message will not be sent.")
+            self.log("WELCOME_CHANNEL environment variable is not defined. Member join message will not be sent.")
             return
 
         channel = self.get_channel(channel_id)

--- a/app/bot.py
+++ b/app/bot.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import time
+import random
 from datetime import datetime
 from typing import Optional
 
@@ -174,6 +175,22 @@ class Bot(commands.Bot):
             return
 
         await self.process_commands(message)
+
+    async def on_member_join(self,member: discord.Member):
+        if member.guild.id != self.config.mcoding_server_id:
+            #Safe to return since this bot will not be on servers besides MCoding
+            return
+
+        channel_id = self.config.welcome_channel
+        if channel_id == None:
+            self.log(f"CUSTOM_INVITE_CHANNEL environment variable is not defined. Member join message will not be sent.")
+            return
+
+        channel = self.get_channel(channel_id)
+        join_message = random.choice(self.config.join_messages)
+        message = await channel.send(join_message.format(member=member.mention))
+        await message.add_reaction( "👋")
+
 
     async def on_connect(self):
         self.log(f"Logged in as {self.user} after {time.perf_counter():,.3f}s")

--- a/app/bot.py
+++ b/app/bot.py
@@ -182,7 +182,7 @@ class Bot(commands.Bot):
             return
 
         channel_id = self.config.welcome_channel
-        if channel_id == None:
+        if channel_id is None:
             self.log(f"CUSTOM_INVITE_CHANNEL environment variable is not defined. Member join message will not be sent.")
             return
 

--- a/app/bot.py
+++ b/app/bot.py
@@ -189,7 +189,7 @@ class Bot(commands.Bot):
         channel = self.get_channel(channel_id)
         join_message = random.choice(self.config.join_messages)
         message = await channel.send(join_message.format(member=member.mention))
-        await message.add_reaction( "👋")
+        await message.add_reaction("👋")
 
     async def on_connect(self):
         self.log(f"Logged in as {self.user} after {time.perf_counter():,.3f}s")

--- a/app/bot.py
+++ b/app/bot.py
@@ -176,7 +176,7 @@ class Bot(commands.Bot):
 
         await self.process_commands(message)
 
-    async def on_member_join(self,member: discord.Member):
+    async def on_member_join(self, member: discord.Member):
         if member.guild.id != self.config.mcoding_server_id:
             #Safe to return since this bot will not be on servers besides MCoding
             return
@@ -190,7 +190,6 @@ class Bot(commands.Bot):
         join_message = random.choice(self.config.join_messages)
         message = await channel.send(join_message.format(member=member.mention))
         await message.add_reaction( "👋")
-
 
     async def on_connect(self):
         self.log(f"Logged in as {self.user} after {time.perf_counter():,.3f}s")

--- a/app/config.py
+++ b/app/config.py
@@ -40,7 +40,7 @@ class Config:
             int(c) for c in env.pop("AUTOPUBLISH_USERS").split(" ")
         ]
 
-        self.join_messages = open("assets/join_messages").read().strip().split("\n")
+        self.join_messages = open("assets/join_messages").read().strip().splitlines()
 
     @classmethod
     def load(cls: Type["Config"], file: str = ".env") -> "Config":

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,8 @@ class Config:
         self.sub_count_channel = int_or_none("SUBSCRIBER_COUNT_CHANNEL")
         self.view_count_channel = int_or_none("VIEW_COUNT_CHANNEL")
 
+        self.welcome_channel = int_or_none("WELCOME_CHANNEL")
+
         self.donor_role_id = int_or_none("DONOR_ROLE")
         self.patron_role_id = int_or_none("PATRON_ROLE")
 
@@ -37,6 +39,8 @@ class Config:
         self.autopublish_user_ids = [
             int(c) for c in env.pop("AUTOPUBLISH_USERS").split(" ")
         ]
+
+        self.join_messages = open("assets/join_messages").read().strip().split("\n")
 
     @classmethod
     def load(cls: Type["Config"], file: str = ".env") -> "Config":

--- a/assets/join_messages
+++ b/assets/join_messages
@@ -1,0 +1,1 @@
+{member} joined the server!


### PR DESCRIPTION
MCoding bot will say a custom join message when a user joins the server. Join Messages need to be disabled on the server before this is in production or two messages will send when someone joins.
**Needed Environment Variables**
WELCOME_CHANNEL=Channel ID

Custom join messages are stored in `assets/join_messages`. If the location is changed it also needs to be changed in `app/config.py`.  Theres only one rn so hopefully some people think of a few more.